### PR TITLE
[LFXV2-122] GET committtees endpoints

### DIFF
--- a/cmd/committee-api/README.md
+++ b/cmd/committee-api/README.md
@@ -13,6 +13,13 @@ This service contains the following API endpoints:
 
 - `/committees`
   - `POST`: create a new committee with base information and settings
+  - `GET /{uid}`: retrieve committee base information by UID (includes public data like name, category, description, voting settings, etc.)
+  - `PUT /{uid}`: update committee base information
+  - `DELETE /{uid}`: delete a committee by UID
+
+- `/committees/{uid}/settings`
+  - `GET`: retrieve committee settings by committee UID (includes sensitive data like writers, auditors, business email requirements)
+  - `PUT`: update committee settings
 
 ## File Structure
 
@@ -48,7 +55,8 @@ This service follows clean architecture principles with clear separation of conc
    - Dependency injection and startup (`main.go`)
 
 2. **Service/Use Case Layer** (`internal/service/`)
-   - `CommitteeWriter` orchestrates committee creation and management
+   - `CommitteeWriter` orchestrates committee creation, updates, and deletion
+   - `CommitteeReader` orchestrates committee data retrieval operations
    - Contains business logic for committee operations
    - Validates business rules and coordinates between domain and infrastructure
 

--- a/cmd/committee-api/main.go
+++ b/cmd/committee-api/main.go
@@ -65,7 +65,7 @@ func main() {
 	committeePublisher := service.CommitteePublisherImpl(ctx)
 	authService := service.AuthServiceImpl(ctx)
 
-	// Initialize the service with use case
+	// Initialize the service with use cases
 	createCommitteeUseCase := usecaseSvc.NewCommitteeWriterOrchestrator(
 		usecaseSvc.WithCommitteeRetriever(committeeRetriever),
 		usecaseSvc.WithCommitteeWriter(committeeWriter),
@@ -73,7 +73,11 @@ func main() {
 		usecaseSvc.WithCommitteePublisher(committeePublisher),
 	)
 
-	committeeServiceSvc := service.NewCommitteeService(createCommitteeUseCase, authService)
+	readCommitteeUseCase := usecaseSvc.NewCommitteeReaderOrchestrator(
+		usecaseSvc.WithCommitteeReader(committeeRetriever),
+	)
+
+	committeeServiceSvc := service.NewCommitteeService(createCommitteeUseCase, readCommitteeUseCase, authService)
 
 	// Wrap the services in endpoints that can be invoked from other services
 	// potentially running in different processes.

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ go 1.24.5
 
 require (
 	github.com/auth0/go-jwt-middleware/v2 v2.3.0
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.15.0
 	github.com/nats-io/nats.go v1.44.0
 	github.com/stretchr/testify v1.10.0
 	goa.design/clue v1.2.2
 	goa.design/goa/v3 v3.21.5
+	golang.org/x/sync v0.16.0
 )
 
 require (
@@ -21,7 +23,6 @@ require (
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gohugoio/hashstructure v0.5.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
@@ -36,7 +37,6 @@ require (
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/mod v0.26.0 // indirect
 	golang.org/x/net v0.42.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/term v0.33.0 // indirect
 	golang.org/x/text v0.27.0 // indirect

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -1,0 +1,95 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/port"
+)
+
+// CommitteeReader defines the interface for committee read operations
+type CommitteeReader interface {
+	// GetBase retrieves committee base information by UID and returns the revision
+	GetBase(ctx context.Context, uid string) (*model.CommitteeBase, uint64, error)
+	// GetSettings retrieves committee settings by UID and returns the revision
+	GetSettings(ctx context.Context, uid string) (*model.CommitteeSettings, uint64, error)
+}
+
+// committeeReaderOrchestratorOption defines a function type for setting options
+type committeeReaderOrchestratorOption func(*committeeReaderOrchestrator)
+
+// WithCommitteeReader sets the committee reader
+func WithCommitteeReader(reader port.CommitteeReader) committeeReaderOrchestratorOption {
+	return func(r *committeeReaderOrchestrator) {
+		r.committeeReader = reader
+	}
+}
+
+// committeeReaderOrchestrator orchestrates the committee reading process
+type committeeReaderOrchestrator struct {
+	committeeReader port.CommitteeReader
+}
+
+// GetBase retrieves committee base information by UID
+func (rc *committeeReaderOrchestrator) GetBase(ctx context.Context, uid string) (*model.CommitteeBase, uint64, error) {
+
+	slog.DebugContext(ctx, "executing get committee base use case",
+		"committee_uid", uid,
+	)
+
+	// Get committee base from storage
+	committeeBase, revision, err := rc.committeeReader.GetBase(ctx, uid)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to get committee base",
+			"error", err,
+			"committee_uid", uid,
+		)
+		return nil, 0, err
+	}
+
+	slog.DebugContext(ctx, "committee base retrieved successfully",
+		"committee_uid", uid,
+		"committee_name", committeeBase.Name,
+		"revision", revision,
+	)
+
+	return committeeBase, revision, nil
+}
+
+// GetSettings retrieves committee settings by UID
+func (rc *committeeReaderOrchestrator) GetSettings(ctx context.Context, uid string) (*model.CommitteeSettings, uint64, error) {
+
+	slog.DebugContext(ctx, "executing get committee settings use case",
+		"committee_uid", uid,
+	)
+
+	// Get committee settings from storage
+	committeeSettings, revision, err := rc.committeeReader.GetSettings(ctx, uid)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to get committee settings",
+			"error", err,
+			"committee_uid", uid,
+		)
+		return nil, 0, err
+	}
+
+	slog.DebugContext(ctx, "committee settings retrieved successfully",
+		"committee_uid", uid,
+		"revision", revision,
+	)
+
+	return committeeSettings, revision, nil
+}
+
+// NewCommitteeReaderOrchestrator creates a new committee reader use case using the option pattern
+func NewCommitteeReaderOrchestrator(opts ...committeeReaderOrchestratorOption) CommitteeReader {
+	rc := &committeeReaderOrchestrator{}
+	for _, opt := range opts {
+		opt(rc)
+	}
+	return rc
+}

--- a/internal/service/committee_reader_test.go
+++ b/internal/service/committee_reader_test.go
@@ -1,0 +1,409 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/infrastructure/mock"
+	errs "github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
+)
+
+func TestCommitteeReaderOrchestratorGetBase(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := mock.NewMockRepository()
+
+	// Setup test data
+	testCommitteeUID := uuid.New().String()
+	testCommittee := &model.Committee{
+		CommitteeBase: model.CommitteeBase{
+			UID:              testCommitteeUID,
+			ProjectUID:       "test-project-uid",
+			ProjectName:      "Test Project",
+			Name:             "Test Committee",
+			Category:         "technical",
+			Description:      "Test committee description",
+			EnableVoting:     true,
+			SSOGroupEnabled:  false,
+			RequiresReview:   true,
+			Public:           false,
+			TotalMembers:     5,
+			TotalVotingRepos: 3,
+			CreatedAt:        time.Now().Add(-24 * time.Hour),
+			UpdatedAt:        time.Now(),
+		},
+		CommitteeSettings: &model.CommitteeSettings{
+			UID:                   testCommitteeUID,
+			BusinessEmailRequired: true,
+			Writers:               []string{"writer1", "writer2"},
+			Auditors:              []string{"auditor1"},
+			CreatedAt:             time.Now().Add(-24 * time.Hour),
+			UpdatedAt:             time.Now(),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		setupMock     func()
+		committeeUID  string
+		expectedError bool
+		errorType     error
+		validateBase  func(*testing.T, *model.CommitteeBase, uint64)
+	}{
+		{
+			name: "successful committee base retrieval",
+			setupMock: func() {
+				mockRepo.ClearAll()
+				// Store the committee in mock repository
+				mockRepo.AddCommittee(testCommittee)
+			},
+			committeeUID:  testCommitteeUID,
+			expectedError: false,
+			validateBase: func(t *testing.T, base *model.CommitteeBase, revision uint64) {
+				assert.NotNil(t, base)
+				assert.Equal(t, testCommitteeUID, base.UID)
+				assert.Equal(t, "test-project-uid", base.ProjectUID)
+				assert.Equal(t, "Test Project", base.ProjectName)
+				assert.Equal(t, "Test Committee", base.Name)
+				assert.Equal(t, "technical", base.Category)
+				assert.Equal(t, "Test committee description", base.Description)
+				assert.True(t, base.EnableVoting)
+				assert.False(t, base.SSOGroupEnabled)
+				assert.True(t, base.RequiresReview)
+				assert.False(t, base.Public)
+				assert.Equal(t, 5, base.TotalMembers)
+				assert.Equal(t, 3, base.TotalVotingRepos)
+				assert.NotZero(t, base.CreatedAt)
+				assert.NotZero(t, base.UpdatedAt)
+				assert.Equal(t, uint64(1), revision) // Mock returns revision 1
+			},
+		},
+		{
+			name: "committee not found error",
+			setupMock: func() {
+				mockRepo.ClearAll()
+				// Don't store any committee
+			},
+			committeeUID:  "nonexistent-committee-uid",
+			expectedError: true,
+			errorType:     errs.NotFound{},
+			validateBase: func(t *testing.T, base *model.CommitteeBase, revision uint64) {
+				assert.Nil(t, base)
+				assert.Equal(t, uint64(0), revision)
+			},
+		},
+		{
+			name: "empty committee UID",
+			setupMock: func() {
+				mockRepo.ClearAll()
+			},
+			committeeUID:  "",
+			expectedError: true,
+			errorType:     errs.NotFound{},
+			validateBase: func(t *testing.T, base *model.CommitteeBase, revision uint64) {
+				assert.Nil(t, base)
+				assert.Equal(t, uint64(0), revision)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			tt.setupMock()
+
+			// Create reader orchestrator
+			reader := NewCommitteeReaderOrchestrator(
+				WithCommitteeReader(mockRepo),
+			)
+
+			// Execute
+			base, revision, err := reader.GetBase(ctx, tt.committeeUID)
+
+			// Validate
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.errorType != nil {
+					assert.IsType(t, tt.errorType, err)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+
+			tt.validateBase(t, base, revision)
+		})
+	}
+}
+
+func TestCommitteeReaderOrchestratorGetSettings(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := mock.NewMockRepository()
+
+	// Setup test data
+	testCommitteeUID := uuid.New().String()
+	testCommittee := &model.Committee{
+		CommitteeBase: model.CommitteeBase{
+			UID:         testCommitteeUID,
+			ProjectUID:  "test-project-uid",
+			ProjectName: "Test Project",
+			Name:        "Test Committee",
+			Category:    "technical",
+			CreatedAt:   time.Now().Add(-24 * time.Hour),
+			UpdatedAt:   time.Now(),
+		},
+		CommitteeSettings: &model.CommitteeSettings{
+			UID:                   testCommitteeUID,
+			BusinessEmailRequired: true,
+			LastReviewedBy:        readerStringPtr("reviewer-uid"),
+			Writers:               []string{"writer1", "writer2"},
+			Auditors:              []string{"auditor1", "auditor2"},
+			CreatedAt:             time.Now().Add(-24 * time.Hour),
+			UpdatedAt:             time.Now(),
+		},
+	}
+
+	tests := []struct {
+		name             string
+		setupMock        func()
+		committeeUID     string
+		expectedError    bool
+		errorType        error
+		validateSettings func(*testing.T, *model.CommitteeSettings, uint64)
+	}{
+		{
+			name: "successful committee settings retrieval",
+			setupMock: func() {
+				mockRepo.ClearAll()
+				// Store the committee in mock repository
+				mockRepo.AddCommittee(testCommittee)
+			},
+			committeeUID:  testCommitteeUID,
+			expectedError: false,
+			validateSettings: func(t *testing.T, settings *model.CommitteeSettings, revision uint64) {
+				assert.NotNil(t, settings)
+				assert.Equal(t, testCommitteeUID, settings.UID)
+				assert.True(t, settings.BusinessEmailRequired)
+				assert.NotNil(t, settings.LastReviewedBy)
+				assert.Equal(t, "reviewer-uid", *settings.LastReviewedBy)
+				assert.Equal(t, []string{"writer1", "writer2"}, settings.Writers)
+				assert.Equal(t, []string{"auditor1", "auditor2"}, settings.Auditors)
+				assert.NotZero(t, settings.CreatedAt)
+				assert.NotZero(t, settings.UpdatedAt)
+				assert.Equal(t, uint64(1), revision) // Mock returns revision 1
+			},
+		},
+		{
+			name: "committee settings not found error",
+			setupMock: func() {
+				mockRepo.ClearAll()
+				// Don't store any committee
+			},
+			committeeUID:  "nonexistent-committee-uid",
+			expectedError: true,
+			errorType:     errs.NotFound{},
+			validateSettings: func(t *testing.T, settings *model.CommitteeSettings, revision uint64) {
+				assert.Nil(t, settings)
+				assert.Equal(t, uint64(0), revision)
+			},
+		},
+		{
+			name: "empty committee UID",
+			setupMock: func() {
+				mockRepo.ClearAll()
+			},
+			committeeUID:  "",
+			expectedError: true,
+			errorType:     errs.NotFound{},
+			validateSettings: func(t *testing.T, settings *model.CommitteeSettings, revision uint64) {
+				assert.Nil(t, settings)
+				assert.Equal(t, uint64(0), revision)
+			},
+		},
+		{
+			name: "committee exists but no settings",
+			setupMock: func() {
+				mockRepo.ClearAll()
+				// For this test, we'll just test with a different committee UID that doesn't exist
+				// This simulates the case where settings are missing
+			},
+			committeeUID:  "committee-with-no-settings",
+			expectedError: true,
+			errorType:     errs.NotFound{},
+			validateSettings: func(t *testing.T, settings *model.CommitteeSettings, revision uint64) {
+				assert.Nil(t, settings)
+				assert.Equal(t, uint64(0), revision)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			tt.setupMock()
+
+			// Create reader orchestrator
+			reader := NewCommitteeReaderOrchestrator(
+				WithCommitteeReader(mockRepo),
+			)
+
+			// Execute
+			settings, revision, err := reader.GetSettings(ctx, tt.committeeUID)
+
+			// Validate
+			if tt.expectedError {
+				require.Error(t, err)
+				if tt.errorType != nil {
+					assert.IsType(t, tt.errorType, err)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+
+			tt.validateSettings(t, settings, revision)
+		})
+	}
+}
+
+func TestNewCommitteeReaderOrchestrator(t *testing.T) {
+	mockRepo := mock.NewMockRepository()
+
+	tests := []struct {
+		name     string
+		options  []committeeReaderOrchestratorOption
+		validate func(*testing.T, CommitteeReader)
+	}{
+		{
+			name:    "create with no options",
+			options: []committeeReaderOrchestratorOption{},
+			validate: func(t *testing.T, reader CommitteeReader) {
+				assert.NotNil(t, reader)
+				// Test that it can be used (though it will have nil dependencies)
+				orchestrator, ok := reader.(*committeeReaderOrchestrator)
+				assert.True(t, ok)
+				assert.Nil(t, orchestrator.committeeReader)
+			},
+		},
+		{
+			name: "create with committee reader option",
+			options: []committeeReaderOrchestratorOption{
+				WithCommitteeReader(mockRepo),
+			},
+			validate: func(t *testing.T, reader CommitteeReader) {
+				assert.NotNil(t, reader)
+				orchestrator, ok := reader.(*committeeReaderOrchestrator)
+				assert.True(t, ok)
+				assert.NotNil(t, orchestrator.committeeReader)
+				assert.Equal(t, mockRepo, orchestrator.committeeReader)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Execute
+			reader := NewCommitteeReaderOrchestrator(tt.options...)
+
+			// Validate
+			tt.validate(t, reader)
+		})
+	}
+}
+
+func TestCommitteeReaderOrchestratorIntegration(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := mock.NewMockRepository()
+	mockRepo.ClearAll()
+
+	// Setup test data
+	testCommitteeUID := uuid.New().String()
+	testCommittee := &model.Committee{
+		CommitteeBase: model.CommitteeBase{
+			UID:              testCommitteeUID,
+			ProjectUID:       "integration-test-project",
+			ProjectName:      "Integration Test Project",
+			Name:             "Integration Test Committee",
+			Category:         "governance",
+			Description:      "Committee for integration testing",
+			EnableVoting:     true,
+			SSOGroupEnabled:  true,
+			SSOGroupName:     "integration-test-sso-group",
+			RequiresReview:   false,
+			Public:           true,
+			TotalMembers:     10,
+			TotalVotingRepos: 5,
+			CreatedAt:        time.Now().Add(-48 * time.Hour),
+			UpdatedAt:        time.Now().Add(-1 * time.Hour),
+		},
+		CommitteeSettings: &model.CommitteeSettings{
+			UID:                   testCommitteeUID,
+			BusinessEmailRequired: false,
+			LastReviewedAt:        readerStringPtr("2024-01-01T00:00:00Z"),
+			LastReviewedBy:        readerStringPtr("integration-reviewer"),
+			Writers:               []string{"integration-writer1", "integration-writer2", "integration-writer3"},
+			Auditors:              []string{"integration-auditor1", "integration-auditor2"},
+			CreatedAt:             time.Now().Add(-48 * time.Hour),
+			UpdatedAt:             time.Now().Add(-1 * time.Hour),
+		},
+	}
+
+	// Store the committee
+	mockRepo.AddCommittee(testCommittee)
+
+	// Create reader orchestrator
+	reader := NewCommitteeReaderOrchestrator(
+		WithCommitteeReader(mockRepo),
+	)
+
+	t.Run("get base and settings for same committee", func(t *testing.T) {
+		// Get base
+		base, baseRevision, err := reader.GetBase(ctx, testCommitteeUID)
+		require.NoError(t, err)
+		require.NotNil(t, base)
+
+		// Get settings
+		settings, settingsRevision, err := reader.GetSettings(ctx, testCommitteeUID)
+		require.NoError(t, err)
+		require.NotNil(t, settings)
+
+		// Validate that both operations return consistent data
+		assert.Equal(t, testCommitteeUID, base.UID)
+		assert.Equal(t, testCommitteeUID, settings.UID)
+		assert.Equal(t, baseRevision, settingsRevision) // Should be same revision in mock
+
+		// Validate complete base data
+		assert.Equal(t, "integration-test-project", base.ProjectUID)
+		assert.Equal(t, "Integration Test Project", base.ProjectName)
+		assert.Equal(t, "Integration Test Committee", base.Name)
+		assert.Equal(t, "governance", base.Category)
+		assert.Equal(t, "Committee for integration testing", base.Description)
+		assert.True(t, base.EnableVoting)
+		assert.True(t, base.SSOGroupEnabled)
+		assert.Equal(t, "integration-test-sso-group", base.SSOGroupName)
+		assert.False(t, base.RequiresReview)
+		assert.True(t, base.Public)
+		assert.Equal(t, 10, base.TotalMembers)
+		assert.Equal(t, 5, base.TotalVotingRepos)
+
+		// Validate complete settings data
+		assert.False(t, settings.BusinessEmailRequired)
+		assert.NotNil(t, settings.LastReviewedAt)
+		assert.Equal(t, "2024-01-01T00:00:00Z", *settings.LastReviewedAt)
+		assert.NotNil(t, settings.LastReviewedBy)
+		assert.Equal(t, "integration-reviewer", *settings.LastReviewedBy)
+		assert.Equal(t, []string{"integration-writer1", "integration-writer2", "integration-writer3"}, settings.Writers)
+		assert.Equal(t, []string{"integration-auditor1", "integration-auditor2"}, settings.Auditors)
+	})
+}
+
+// Helper function to create string pointer (same as in committee_writer_test.go)
+func readerStringPtr(s string) *string {
+	return &s
+}

--- a/internal/service/committee_writer.go
+++ b/internal/service/committee_writer.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
@@ -202,7 +203,17 @@ func (uc *committeeWriterOrchestrator) Create(ctx context.Context, committee *mo
 		"name", committee.Name,
 	)
 
+	// Set committee identifiers and timestamps
+	now := time.Now()
 	committee.CommitteeBase.UID = uuid.New().String()
+	committee.CommitteeBase.CreatedAt = now
+	committee.CommitteeBase.UpdatedAt = now
+
+	// Set timestamps for committee settings if they exist
+	if committee.CommitteeSettings != nil {
+		committee.CommitteeSettings.CreatedAt = now
+		committee.CommitteeSettings.UpdatedAt = now
+	}
 
 	// for rollback purposes
 	var (


### PR DESCRIPTION
## Overview

* https://linuxfoundation.atlassian.net/browse/LFXV2-122

Implement GET /committees/{id} endpoint for retrieving specific committee
Implement GET /committees/{id}/project_settings endpoint for retrieving committee settings

This pull request introduces a new read use case for committee base information and settings, refactors the service layer to support separate read and write orchestrators, and implements the necessary API endpoints and data conversion logic. It also includes minor dependency updates and ensures correct handling of timestamps when creating committees.

## Test Summary
✅ **All endpoints working correctly**  
🚀 **API Server**: `http://localhost:8080`  

## Valid Committee Endpoints Testing

### 1. Committee Details Endpoint: `/committees/{uid}?v=1`

#### ✅ Committee ID: `f23686ca-23d6-44eb-9f2b-a60c546d5b09`
```bash
curl "http://localhost:8080/committees/f23686ca-23d6-44eb-9f2b-a60c546d5b09?v=1"
```
**Response**: `HTTP 200` (0.864s)
```json
{
  "uid": "f23686ca-23d6-44eb-9f2b-a60c546d5b09",
  "project_uid": "5ad95cec-27eb-46d9-819e-88484d67e229",
  "name": "Technical Steering Committee 001",
  "category": "Technical Steering Committee",
  "description": "Main technical oversight committee for the project",
  "website": "https://committee.example.org",
  "enable_voting": true,
  "sso_group_enabled": true,
  "requires_review": true,
  "public": true,
  "calendar": { "public": true },
  "display_name": "TSC Committee Calendar",
  "sso_group_name": "project-6726-technical-steering-committee-001",
  "total_members": 0,
  "total_voting_repos": 0
}
```

#### ✅ Committee ID: `e68ae705-6260-4db6-a558-514755df1e52`
**Response**: `HTTP 200` (0.660s)
```json
{
  "uid": "e68ae705-6260-4db6-a558-514755df1e52",
  "name": "Technical Steering Committee Child 26",
  "category": "Technical Steering Committee",
  // ... similar structure
}
```

#### ✅ Committee ID: `4ffd7c80-1604-4d3a-9878-34a8cf7fe34b`
**Response**: `HTTP 200` (0.002s)
```json
{
  "uid": "4ffd7c80-1604-4d3a-9878-34a8cf7fe34b",
  "name": "Technical Steering Committee Child 27",
  // ... similar structure
}
```

#### ✅ Committee ID: `5ea655c2-7673-4371-b665-49204f22142b`
**Response**: `HTTP 200` (0.002s)
```json
{
  "uid": "5ea655c2-7673-4371-b665-49204f22142b",
  "name": "Technical Steering Committee 01",
  // ... similar structure
}
```

#### ✅ Committee ID: `6ecf5866-3859-44f6-b068-c9f71f47f0a3`
**Response**: `HTTP 200` (0.002s)
```json
{
  "uid": "6ecf5866-3859-44f6-b068-c9f71f47f0a3",
  "name": "Technical Steering Committee 003",
  // ... similar structure
}
```

### 2. Committee Settings Endpoint: `/committees/{uid}/settings?v=1`

#### ✅ Committee Settings: `f23686ca-23d6-44eb-9f2b-a60c546d5b09`
```bash
curl "http://localhost:8080/committees/f23686ca-23d6-44eb-9f2b-a60c546d5b09/settings?v=1"
```
**Response**: `HTTP 200` (0.003s)
```json
{
  "uid": "f23686ca-23d6-44eb-9f2b-a60c546d5b09",
  "business_email_required": false,
  "last_reviewed_at": "2023-05-10T09:15:00Z",
  "last_reviewed_by": "user_id_12345"
}
```

#### ✅ Committee Settings: `e68ae705-6260-4db6-a558-514755df1e52`
**Response**: `HTTP 200` (0.002s)
```json
{
  "uid": "e68ae705-6260-4db6-a558-514755df1e52",
  "business_email_required": false,
  "last_reviewed_at": "2023-05-10T09:15:00Z",
  "last_reviewed_by": "user_id_12345"
}
```

## Error Handling Testing

### 3. Not Found Scenarios

#### ❌ Non-existent Committee ID: `12345678-1234-4567-8901-123456789012`
```bash
curl "http://localhost:8080/committees/12345678-1234-4567-8901-123456789012?v=1"
```
**Response**: `HTTP 404` (0.002s)
```json
{
  "message": "committee not found: committee UID: 12345678-1234-4567-8901-123456789012"
}
```

#### ❌ Non-existent Committee Settings: `12345678-1234-4567-8901-123456789012`
```bash
curl "http://localhost:8080/committees/12345678-1234-4567-8901-123456789012/settings?v=1"
```
**Response**: `HTTP 404` (0.002s)
```json
{
  "message": "committee settings not found: committee UID: 12345678-1234-4567-8901-123456789012"
}
```

### 4. Invalid UUID Format Scenarios

#### ❌ Invalid UUID Format: `invalid-uuid-format`
```bash
curl "http://localhost:8080/committees/invalid-uuid-format?v=1"
```
**Response**: `HTTP 400` (0.001s)
```json
{
  "name": "invalid_format",
  "id": "sADFn4d7",
  "message": "uid must be formatted as a uuid but got value \"invalid-uuid-format\", uuid: invalid-uuid-format: invalid UUID length: 19",
  "temporary": false,
  "timeout": false,
  "fault": false
}
```

#### ❌ Invalid UUID Format Settings: `invalid-uuid-format`
```bash
curl "http://localhost:8080/committees/invalid-uuid-format/settings?v=1"
```
**Response**: `HTTP 400` (0.001s)
```json
{
  "name": "invalid_format",
  "id": "Ve8eT8RQ",
  "message": "uid must be formatted as a uuid but got value \"invalid-uuid-format\", uuid: invalid-uuid-format: invalid UUID length: 19",
  "temporary": false,
  "timeout": false,
  "fault": false
}
```

## Key Findings

✅ **Successful Operations**:
- All 5 provided committee IDs return valid data
- Both `/committees/{uid}` and `/committees/{uid}/settings` endpoints working
- Fast response times (1-864ms)
- Consistent JSON structure across all responses

✅ **Proper Error Handling**:
- `HTTP 404` for non-existent committee IDs with clear error messages
- `HTTP 400` for invalid UUID formats with detailed validation errors
- Consistent error response structure with unique error IDs

✅ **API Validation**:
- Strict RFC4122 UUID validation implemented
- Different error messages for "not found" vs "invalid format"
- Both endpoints handle errors consistently

The committee API endpoints are working correctly with proper validation, error handling, and consistent response formats.